### PR TITLE
Making The Filter For Departments Into A Reusable Componenet

### DIFF
--- a/src/components/Courses.vue
+++ b/src/components/Courses.vue
@@ -35,7 +35,7 @@ export default {
 
   computed: {
     courseListByDepartment() {
-      let component_department = this.department || this.$store.state.route.params.department;
+      let component_department = this.department || this.$store.state.department.selected_department;
       let component_semester = this.semester || this.$store.state.route.params.semester;
       let component_level = this.level || this.$store.state.route.params.level;
       let courses_data = this.$store.state.courses.lists[component_semester] || [];

--- a/src/components/DepartmentFilter.vue
+++ b/src/components/DepartmentFilter.vue
@@ -1,0 +1,180 @@
+<template>
+  <div v-if="route_link" class="buttons" :class="selected_department">
+    <router-link v-for="department in departments" :to="route_link + department.department_id" :key="department.department_id" :class="department.department_id" :name="department.department_id">{{department.department_id.replace('_', ' ')}}</router-link>
+  </div>
+  <div v-else class="buttons" :class="selected_department">
+    <button v-for="department in departments" v-on:click="filter" :class="department.department_id" :key="department.department_id" :filter-value="department.department_id">{{ department.department_id.replace('_', ' ') }}</button>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+
+function fetchDepartments(store) {
+  store.dispatch('GET_SCS_DEPARTMENT_LIST');
+
+  if (store.state.route.params.department){
+    store.commit("SET_SELECTED_DEPARTMENT", store.state.route.params.department);
+  }
+}
+
+export default {
+  name: 'department_filter',
+
+  preFetch: fetchDepartments,
+
+  props: ['route_link', 'types', 'excluded_departments'],
+
+  beforeMount () {
+    fetchDepartments(this.$store);
+  },
+
+  computed: {
+    departments() {
+      let types = this.types || [];
+      let excluded_departments = this.excluded_departments || [];
+
+      return this.$store.state.department.scs_list.filter((department) => {
+        return types.includes(department.scs_type) && !excluded_departments.includes(department.department_id);
+      });
+    },
+    selected_department() {
+      return this.$store.state.department.selected_department;
+    }
+  },
+
+  methods: {
+    filter(event) {
+      let filter_value = event.target.getAttribute('filter-value');
+      if (filter_value && this.$store.state.department.selected_department !== filter_value)
+        this.$store.commit("SET_SELECTED_DEPARTMENT", filter_value);
+      else
+        this.$store.commit("SET_SELECTED_DEPARTMENT", '');
+    }
+  }
+}
+</script>
+
+<style lang="stylus" scoped>
+.buttons {
+  margin-top: 1.6em;
+  border-top: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+  a, button {
+    display: inline-block;
+    margin-right: 2em;
+    margin-top: 1.6em;
+    margin-bottom: 1.6em;
+    -webkit-appearance: none;
+    text-transform: uppercase;
+    color: #2c3e50;
+    color: white;
+    font-weight: 900;
+    font-size: .9em;
+    padding: .5em 1.2em .5em 1.2em;
+    border: none;
+    border-bottom: 4px solid;
+    font-family: Noto Sans,Helvetica,sans-serif;
+    &.all{
+      background-color: #2c3e50;
+      &:hover{
+        border-color: #2c3e50;
+      }
+    }
+    &.ri{
+      background-color: #9b22b4;
+      &:hover{
+        border-color: #9b22b4;
+      }
+    }
+    &.lti{
+      background-color: #3bb422;
+      &:hover{
+        border-color: #3bb422;
+      }
+    }
+    &.csd{
+      background-color: #22b49b;
+      &:hover{
+        border-color: #22b49b;
+      }
+    }
+    &.hcii{
+      background-color: #b49b22;
+      &:hover{
+        border-color: #b49b22;
+      }
+    }
+    &.compbio{
+      background-color: #b45222;
+      &:hover{
+        border-color: #b45222;
+      }
+    }
+    &.deans_office, &.scs{
+      background-color: #C41230;
+      &:hover, .active{
+        border-color: #C41230;
+      }
+    }
+    &.isr{
+      background-color: #165574;
+      &:hover{
+        border-color: #165574;
+      }
+    }
+    &.mld{
+      background-color: #b42284;
+      &:hover{
+        border-color: #b42284;
+      }
+    }
+    &:hover{
+      text-decoration: none;
+      color: #2c3e50;
+      background-color: white;
+    }
+  }
+  &.ri a.ri, &.ri button.ri{
+    background-color: transparent;
+    border-color: #9b22b4;
+    color: #9b22b4;
+  }
+  &.lti a.lti, &.lti button.lti{
+    background-color: transparent;
+    border-color: #3bb422;
+    color: #3bb422;
+  }
+  &.csd a.csd, &.csd button.csd{
+    background-color: transparent;
+    border-color: #22b49b;
+    color: #22b49b;
+  }
+  &.hcii a.hcii, &.hcii button.hcii{
+    background-color: transparent;
+    border-color: #b49b22;
+    color: #b49b22;
+  }
+  &.compbio a.compbio, &.compbio button.compbio {
+    background-color: transparent;
+    border-color: #b45222;
+    color: #b45222;
+  }
+  &.deans_office a.scs,
+  &.scs a.scs, &.deans_office button.deans_office, , &.scs button.scs{
+    background-color: transparent;
+    border-color: #C41230;
+    color: #C41230;
+  }
+  &.isr a.isr, &.isr button.isr {
+    background-color: transparent;
+    border-color: #165574;
+    color: #165574;
+  }
+  &.mld a.mld, &.mld button.mld{
+    background-color: transparent;
+    border-color: #b42284;
+    color: #b42284;
+  }
+}
+</style>

--- a/src/components/Programs.vue
+++ b/src/components/Programs.vue
@@ -49,6 +49,10 @@ export default {
 
   props: ['degree_level', 'department', 'graduate_level', 'condensed'],
 
+  components: {
+    Spinner,
+  },
+
   preFetch: fetchPrograms,
 
   computed: {

--- a/src/store/modules/department.js
+++ b/src/store/modules/department.js
@@ -5,7 +5,9 @@ import gql from 'graphql-tag'
 export default {
   state: {
     department: {},
-    list: []
+    list: [],
+    scs_list: [],
+    selected_department: ''
   },
   actions: {
     GET_DEPARTMENT: ({ commit, state }, fields = {}) => {
@@ -58,6 +60,31 @@ export default {
           console.error(err.locations)
           console.error(`GraphQL Error: ${err.message}`)
         })
+    },
+    GET_SCS_DEPARTMENT_LIST: ({ commit, state }, fields = {}) => {
+      return state.scs_list.length
+        ? Promise.resolve(state.scs_list)
+        : apollo.query({
+          query: gql`
+            {
+              departments(college_id:"scs") {
+                department_id
+                department_name
+                scs_type
+              }
+            }
+          `
+        }).then((res,err) => {
+          if (res) {
+            commit('SET_SCS_DEPARTMENT_LIST', res.data)
+            return res.data
+          } else {
+            Promise.reject(":err :department graphql failed")
+          }
+        }).catch((err) =>{
+          console.error(err.locations)
+          console.error(`GraphQL Error: ${err.message}`)
+        })
     }
   },
   mutations: {
@@ -66,6 +93,12 @@ export default {
     },
     SET_DEPARTMENT_LIST: (state, data) => {
       state.list = data.directoryAggregate
+    },
+    SET_SCS_DEPARTMENT_LIST: (state, data) => {
+      state.scs_list = data.departments;
+    },
+    SET_SELECTED_DEPARTMENT: (state, department) => {
+      state.selected_department = department;
     }
   }
 }

--- a/src/views/CourseListView.vue
+++ b/src/views/CourseListView.vue
@@ -1,17 +1,6 @@
 <template>
   <div class="courses-view">
-    <spinner class="spinner" v-if="!loaded" key="spinner"></spinner>
-    <div class="dep-buttons" :class="nav">
-      <a href="#" v-on:click="filter" class="all" filter-name="department">all</a>
-      <a href="#" v-on:click="filter" class="csd" filter-name="department" filter-value="csd">csd</a>
-      <a href="#" v-on:click="filter" class="lti" filter-name="department" filter-value="lti">lti</a>
-      <a href="#" v-on:click="filter" class="hcii" filter-name="department" filter-value="hcii">hcii</a>
-      <a href="#" v-on:click="filter" class="ri" filter-name="department" filter-value="ri">ri</a>
-      <a href="#" v-on:click="filter" class="compbio" filter-name="department" filter-value="compbio">cbd</a>
-      <a href="#" v-on:click="filter" class="mld" filter-name="department" filter-value="mld">mld</a>
-      <a href="#" v-on:click="filter" class="isr" filter-name="department" filter-value="isr">isr</a>
-      <a href="#" v-on:click="filter" class="isr" filter-name="department" filter-value="etc">etc</a>
-    </div>
+    <DepartmentFilter :types="scs_department_types"></DepartmentFilter>
     <div class="level-buttons" :class="level">
       <button class="U" v-on:click="filter" filter-name="level" filter-value="U">Undergraduate</button>
       <button class="G" v-on:click="filter" filter-name="level" filter-value="G">Graduate</button>
@@ -21,8 +10,8 @@
 </template>
 
 <script>
-import Spinner from '../components/Spinner.vue'
 import Courses from '../components/Courses.vue'
+import DepartmentFilter from '../components/DepartmentFilter.vue'
 import { router } from '../app'
 
 function fetchCourses(store) {
@@ -33,8 +22,8 @@ export default {
   name: 'courses-list-view',
 
   components: {
-    Spinner,
-    Courses
+    Courses,
+    DepartmentFilter
   },
 
   data() {
@@ -42,7 +31,8 @@ export default {
       semester: this.$store.state.route.params.semester,
       department: '',
       level: '',
-      nav: ''
+      nav: '',
+      scs_department_types: ['academic']
     }
   },
 

--- a/src/views/DirectoryView.vue
+++ b/src/views/DirectoryView.vue
@@ -1,7 +1,6 @@
 <template>
   <section class="page">
     <div class="directory-list">
-      <Spinner class="spinner" v-if="!loaded" key="spinner"></Spinner>
       <div class="filter-toggle" v-if="loaded">
         <form class="search">
           <input class="filter-input" v-model="query" :placeholder="placeholder" name="query" autocomplete="off">
@@ -12,17 +11,7 @@
           <button class="Staff" @click="titleFilter('Staff')" name="staff">Staff</button>
         </div>
 
-        <div class="dep-buttons" :class="nav">
-          <router-link :to="'/directory/'" class="all">all</router-link>
-          <router-link :to="'/directory/department/csd'" class="csd" name="csd">csd</router-link>
-          <router-link :to="'/directory/department/lti'" class="lti" name="lti">lti</router-link>
-          <router-link :to="'/directory/department/hcii'" class="hcii" name="hcii">hcii</router-link>
-          <router-link :to="'/directory/department/ri'" class="ri" name="ri">ri</router-link>
-          <router-link :to="'/directory/department/deans_office'" class="scs" name="scs">scs</router-link>
-          <router-link :to="'/directory/department/compbio'" class="compbio" name="compbio">cbd</router-link>
-          <router-link :to="'/directory/department/mld'" class="mld" name="mld">mld</router-link>
-          <router-link :to="'/directory/department/isr'" class="isr" name="isr">isr</router-link>
-        </div>
+        <DepartmentFilter :route_link="route_link" :types="scs_department_types" :excluded_departments="excluded_departments"></DepartmentFilter>
 
         <div class="count">showing : {{ directoryShown}} / {{directoryLength}}</div>
       </div>
@@ -39,10 +28,10 @@
 
 <script>
 import Vue from 'vue'
-import Spinner from '../components/Spinner.vue'
 import _ from 'lodash'
 import DirectoryListItem from '../components/DirectoryListItem.vue'
 import VirtualScroller from '../components/VirtualScroller.vue'
+import DepartmentFilter from '../components/DepartmentFilter.vue'
 
 const renderers = {
   person: DirectoryListItem
@@ -58,9 +47,9 @@ export default {
   preFetch: fetchDirectory,
 
   components: {
-    Spinner,
     DirectoryListItem,
-    VirtualScroller
+    VirtualScroller,
+    DepartmentFilter
   },
 
   data () {
@@ -70,7 +59,10 @@ export default {
       directory: [],
       directoryLength: 0,
       directoryShown: 0,
-      depTitle: ''
+      depTitle: '',
+      route_link: '/directory/department/',
+      scs_department_types: ['academic', 'admin', 'school'],
+      excluded_departments: ['scs_facilities']
     }
   },
 
@@ -224,132 +216,6 @@ export default {
   padding: 0;
   position: relative;
   min-height: 20em;
-}
-
-.dep-buttons {
-  margin-top: 1.6em;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-  a {
-    display: inline-block;
-    margin-right: 2em;
-    margin-top: 1.6em;
-    margin-bottom: 1.6em;
-    -webkit-appearance: none;
-    text-transform: uppercase;
-    color: #2c3e50;
-    color: white;
-    font-weight: 900;
-    font-size: .9em;
-    padding: .5em 1.2em .5em 1.2em;
-    border: none;
-    border-bottom: 4px solid;
-    &.all{
-      background-color: #2c3e50;
-      &:hover{
-        border-color: #2c3e50;
-      }
-    }
-    &.ri{
-      background-color: #9b22b4;
-      &:hover{
-        border-color: #9b22b4;
-      }
-    }
-    &.lti{
-      background-color: #3bb422;
-      &:hover{
-        border-color: #3bb422;
-      }
-    }
-    &.csd{
-      background-color: #22b49b;
-      &:hover{
-        border-color: #22b49b;
-      }
-    }
-    &.hcii{
-      background-color: #b49b22;
-      &:hover{
-        border-color: #b49b22;
-      }
-    }
-    &.compbio{
-      background-color: #b45222;
-      &:hover{
-        border-color: #b45222;
-      }
-    }
-    &.deans_office, &.scs{
-      background-color: #C41230;
-      &:hover, .active{
-        border-color: #C41230;
-      }
-    }
-    &.isr{
-      background-color: #165574;
-      &:hover{
-        border-color: #165574;
-      }
-    }
-    &.mld{
-      background-color: #b42284;
-      &:hover{
-        border-color: #b42284;
-      }
-    }
-    &:hover{
-      text-decoration: none;
-      color: #2c3e50;
-      background-color: white;
-    }
-  }
-  &.all a.all{
-    background-color: transparent;
-    border-color: #2c3e50;
-    color: #2c3e50;
-  }
-  &.ri a.ri{
-    background-color: transparent;
-    border-color: #9b22b4;
-    color: #9b22b4;
-  }
-  &.lti a.lti{
-    background-color: transparent;
-    border-color: #3bb422;
-    color: #3bb422;
-  }
-  &.csd a.csd{
-    background-color: transparent;
-    border-color: #22b49b;
-    color: #22b49b;
-  }
-  &.hcii a.hcii{
-    background-color: transparent;
-    border-color: #b49b22;
-    color: #b49b22;
-  }
-  &.compbio a.compbio {
-    background-color: transparent;
-    border-color: #b45222;
-    color: #b45222;
-  }
-  &.deans_office a.scs,
-  &.scs a.scs{
-    background-color: transparent;
-    border-color: #C41230;
-    color: #C41230;
-  }
-  &.isr a.isr {
-    background-color: transparent;
-    border-color: #165574;
-    color: #165574;
-  }
-  &.mld a.mld{
-    background-color: transparent;
-    border-color: #b42284;
-    color: #b42284;
-  }
 }
 
 .filter{

--- a/src/views/ProgramsView.vue
+++ b/src/views/ProgramsView.vue
@@ -10,17 +10,7 @@
     <p>
       And a survey by the editors of The Wall Street Journal ranked our undergraduate computer science program No. 1 in the United States among corporate recruiters.
     </p>
-    <div class="dep-buttons" :class="nav">
-      <a href="javascript:void(0);" v-on:click="filter" class="all" filter-name="department">all</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="csd" filter-name="department" filter-value="csd">csd</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="lti" filter-name="department" filter-value="lti">lti</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="hcii" filter-name="department" filter-value="hcii">hcii</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="ri" filter-name="department" filter-value="ri">ri</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="compbio" filter-name="department" filter-value="compbio">cbd</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="mld" filter-name="department" filter-value="mld">mld</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="isr" filter-name="department" filter-value="isr">isr</a>
-      <a href="javascript:void(0);" v-on:click="filter" class="etc" filter-name="department" filter-value="etc">etc</a>
-    </div>
+    <DepartmentFilter :types="scs_department_types"></DepartmentFilter>
     <div class="level-buttons" :class="graduate_level">
       <button class="U" v-on:click="filter" filter-name="graduate_level" filter-value="undergraduate">Undergraduate</button>
       <button class="G" v-on:click="filter" filter-name="graduate_level" filter-value="graduate">Graduate</button>
@@ -31,20 +21,28 @@
 
 <script>
 import Programs from '../components/Programs.vue'
+import DepartmentFilter from '../components/DepartmentFilter.vue'
 import { router } from '../app'
 
 export default {
   name: 'programs-view',
 
   components: {
-    Programs
+    Programs,
+    DepartmentFilter
   },
 
   data() {
     return {
-      department: '',
       graduate_level: '',
-      degree_level: ''
+      degree_level: '',
+      scs_department_types: ['academic']
+    }
+  },
+
+  computed: {
+    department() {
+      return this.$store.state.department.selected_department;
     }
   },
 
@@ -144,116 +142,6 @@ h4 {
 
 p {
   margin-bottom: 1em;
-}
-
-.dep-buttons {
-  margin-top: 1.6em;
-  border-top: 1px solid #eee;
-  border-bottom: 1px solid #eee;
-  a {
-    display: inline-block;
-    margin-right: 2em;
-    margin-top: 1.6em;
-    margin-bottom: 1.6em;
-    -webkit-appearance: none;
-    text-transform: uppercase;
-    color: #2c3e50;
-    font-weight: 900;
-    font-size: .95em;
-    padding: .5em 1.2em .5em .2em;
-    border: none;
-    border-bottom: 4px solid;
-    &.all, &.etc{
-      border-color: #2c3e50;
-      &:hover{
-        background-color: #2c3e50;
-      }
-    }
-    &.ri{
-      border-color: #9b22b4;
-      &:hover{
-        background-color: #9b22b4;
-      }
-    }
-    &.lti{
-      border-color: #3bb422;
-      &:hover{
-        background-color: #3bb422;
-      }
-    }
-    &.csd{
-      border-color: #22b49b;
-      &:hover{
-        background-color: #22b49b;
-      }
-    }
-    &.hcii{
-      border-color: #b49b22;
-      &:hover{
-        background-color: #b49b22;
-      }
-    }
-    &.compbio{
-      border-color: #b45222;
-      &:hover{
-        background-color: #b45222;
-      }
-    }
-    &.deans_office {
-      border-color: #C41230;
-      &:hover, .active{
-        background-color: #C41230;
-      }
-    }
-    &.isr{
-      border-color: #165574;
-      &:hover{
-        background-color: #165574;
-      }
-    }
-    &.mld{
-      border-color: #b42284;
-      &:hover{
-        background-color: #b42284;
-      }
-    }
-    &:hover{
-      text-decoration: none;
-      color white;
-    }
-  }
-  &.ri a.ri{
-    background-color: #9b22b4;
-    color white;
-  }
-  &.lti a.lti{
-    background-color: #3bb422;
-    color white;
-  }
-  &.csd a.csd{
-    background-color: #22b49b;
-    color white;
-  }
-  &.hcii a.hcii{
-    background-color: #b49b22;
-    color white;
-  }
-  &.compbio a.compbio {
-    background-color: #b45222;
-    color white;
-  }
-  & a.deans_office, &.scs a.scs{
-    background-color: #C41230;
-    color white;
-  }
-  &.isr a.isr {
-    background-color: #165574;
-    color white;
-  }
-  &.mld a.mld{
-    background-color: #b42284;
-    color white;
-  }
 }
 
 .level-buttons {


### PR DESCRIPTION
# Description
## Department Filter Component
- Props: `route_link` - String -  tells the component to use routes links or buttons that don't change navigation. `types` - Array -  tell the component which departments should be used used in the filter based on department type (e.g. 'academic', 'admin', 'school', etc.). `excluded_departments` - Array - tells the component to exclude specific departments from the filter based on department ID.

## Store Changes
- Added a `selected_department` key to the store for departments. This key will persists over different parent views and can be used by different components to filter results of that component, immediately. This directs the user on a streamlined path if they are only interested in information for a specific department.