### PR TITLE
Fixing Directory On Department Pages

### DIFF
--- a/src/components/DepartmentDirectory.vue
+++ b/src/components/DepartmentDirectory.vue
@@ -38,18 +38,25 @@ export default {
       let departmentFilter = this.$store.state.route.params.department;
       let random_indexes = [];
       let directory_length = this.$store.state.directory.list.length;
+      let maxCount = 12;
 
-      while (filtered.length < 12 && directory_length !== 0 && departmentFilter !== 'deans_office') {
-        let rand_num = Math.floor(Math.random() * (directory_length - 1));
-        let person = this.$store.state.directory.list[rand_num];
+      if (directory_length > 0 && !filtered.length) {
+        for(let i = 0; i <= directory_length * 2; i++) {
+          if (filtered.length === maxCount) {
+            break;
+          }
+          
+          let rand_num = Math.floor(Math.random() * (directory_length - 1));
+          let person = this.$store.state.directory.list[rand_num];
 
-        if (person.scs_relationship_class !== 'faculty' || !person.image_url || random_indexes.includes(rand_num)) {
-          continue;
-        }
+          if (person.scs_relationship_class !== 'faculty' || !person.image_url || random_indexes.includes(rand_num)) {
+            continue;
+          }
 
-        if(person.departments.includes(departmentFilter) || !departmentFilter) {
-          filtered.push(person);
-          random_indexes.push(rand_num);
+          if(person.departments.includes(departmentFilter) || !departmentFilter) {
+            filtered.push(person);
+            random_indexes.push(rand_num);
+          }
         }
       }
 


### PR DESCRIPTION
# Description
`while` loop was crashing the browser on certain conditions after the directory update in the datasource. This has been changed to a `for` loop to ensure closed execution (and release of memory) of this logic. I don't like this solution fully, as I think the directory data in the store could be broken out by department, cached, and used a bit easier around our application...but at least the browser crashing won't happen any longer.