### PR TITLE
Adding Courses For Professors to The Member View

### DIFF
--- a/src/store/modules/member.js
+++ b/src/store/modules/member.js
@@ -78,6 +78,13 @@ export default {
                   title
                   pub_year
                 }
+                courses{
+                  longTitle
+                  courseNumber
+                  courseCode
+                  level
+                  department
+                }
               }
             }
           `,

--- a/src/views/MemberView.vue
+++ b/src/views/MemberView.vue
@@ -50,6 +50,11 @@
             </div>
           </section>
 
+          <section v-if="member.courses.length > 0" class="courses">
+            <p class="title">Upcoming Courses</p>
+            <p v-for="course in member.courses"><router-link :to="'/courses/course/' + course.courseCode">{{course.courseNumber}} - {{course.longTitle}}</router-link></p>
+          </section>
+
           <section class="research directory-information">
             <div v-if="member.research_areas">
               <p class="title">Research Areas</p>


### PR DESCRIPTION
# Description
Needs: https://github.com/SchoolofComputerScience/scs-api/pull/23
Added Courses to the Member View to show upcoming courses a certain faculty member is associated to or teaching. Minimal styling. More information, such as actual year and graduate level, will soon be implemented.