### PR TITLE
Loading Global Data To Help Site Latency

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,11 +14,21 @@
 import MainHeader from './components/MainHeader.vue'
 import MainFooter from './components/MainFooter.vue'
 
+function fetchGlobalData(store) {
+  store.dispatch('GET_DIRECTORY');
+  store.dispatch('GET_PROGRAMS')
+  return store.dispatch('GET_RESEARCH_AREAS');
+}
+
 export default {
   name: 'scsmain',
+  preFetch: fetchGlobalData,
   components: {
     MainHeader,
     MainFooter
+  },
+  beforeMount () {
+    fetchGlobalData(this.$store);
   }
 }
 </script>

--- a/src/views/DirectoryView.vue
+++ b/src/views/DirectoryView.vue
@@ -1,7 +1,6 @@
 <template>
   <section class="data-page">
-    <spinner class="spinner" v-if="!loaded" key="spinner"></spinner>
-    <div class="filter-toggle" v-if="loaded">
+    <div class="filter-toggle">
       <form class="search" v-on:submit.prevent>
         <input class="filter-search"
           v-model="query"
@@ -20,6 +19,7 @@
         </div>
       </div>
     </div>
+    <spinner class="spinner" v-if="!loaded" key="spinner"></spinner>
 
     <VirtualScroller
       v-if="loaded"


### PR DESCRIPTION
# Description
The big latency problem that has been expressed by multiple people: The Directory. The directory can sometimes take up to 10+ seconds to load. 

# Solution
My idea to solve this, would be to bring in data to the store, asynchronously and in the background of whatever entry page the user is on to the SCS Website. For example, if a user enters our site through the homepage, in the background, we will fetch all the directory data asynchronously without the user noticing, as the fetching of this data will not interrupt the interaction with the homepage content.

The reason for this idea:
After looking at analytics for the current SCS Website, ~30% of users enters the SCS site on the homepage. We could take advantage of this by loading in data for Programs, Research Areas, and the Directory in the background before they navigate to those pages. This will make the site appear to have less latency. 

*Note*: According to the data ~1% of the users enters the site on the Directory. They will still experience the normal latency, unfortunately.