### PR TITLE
corrected total count for publications

### DIFF
--- a/src/views/MemberView.vue
+++ b/src/views/MemberView.vue
@@ -81,7 +81,7 @@
           </section>
 
           <section v-if="gp" class="publications">
-            <p class="title">Cited Publications <span class="amount">(Amount: {{member.profile[0].gs_citation_count}})</span>
+            <p class="title">Cited Publications <span class="amount">(Amount: {{member.publications.length}})</span>
             </p>
             <div class="list" v-for="pub in member.profile[0].pub_year_agg">
               <h4>{{pub._id}}</h4>


### PR DESCRIPTION
The previous version resulted in an incorrect display of the total count of publications. I believe that the API call for `profile.gs_citation_count` was misinterpreted. 