### PR TITLE
Fixing Department Filter For Courses

### DIFF
--- a/src/components/Courses.vue
+++ b/src/components/Courses.vue
@@ -2,10 +2,10 @@
   <div>
     <transition name="fade" mode="out-in">
       <article>
-        <div v-for="(department, departmentID) in courseListByDepartment" class="content-page card">
+        <div v-for="(department, departmentID) in courseListByDepartment" class="content-page card" :key="departmentID">
           <h3 :id="departmentID.toLowerCase()">{{departmentID | departmentTranslate}}</h3>
           <section class="container">
-            <div class="item" v-for="(course, course_number) in department">
+            <div class="item" v-for="(course, course_number) in department" :key="course_number">
               <router-link class="course-link" v-for="item in course.courseCodes" :key="item.code" :to="'/courses/course/' + item.code">
               <h4><em>{{course_number}}</em> | {{course.graduate_level}} | {{course.long_title}}</h4>
               </router-link>
@@ -27,7 +27,7 @@ export default {
 
   computed: {
     courseListByDepartment() {
-      let component_department = this.department || this.$store.state.department.selected_department;
+      let component_department = this.$store.state.department.selected_department.id;
       let component_semester = this.semester || this.$store.state.route.params.semester;
       let component_level = this.graduate_level || this.$store.state.route.params.graduate_level;
       let courses_data = this.$store.state.courses.lists[component_semester] || [];

--- a/src/components/DepartmentFilter.vue
+++ b/src/components/DepartmentFilter.vue
@@ -1,15 +1,12 @@
 <template>
   <section class="department-filter">
-    <div v-if="route_link" class="dropdown show">
+    <div class="dropdown show">
       <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         {{selected_department.name}}
       </button>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
         <a v-for="department in departments" v-on:click="filter" :key="department.department_id" :dept_id="department.department_id" :dept_name="department.department_name" class="dropdown-item" href="javascript:void(0);">{{department.department_name}}</a>
       </div>
-    </div>
-    <div v-else class="buttons">
-      <button v-for="department in departments" class="button" v-on:click="filter" :class="department.department_id" :key="department.department_id" :filter-value="department.department_id">{{ department.department_id.replace('_', ' ') }}</button>
     </div>
   </section>
 </template>
@@ -62,7 +59,7 @@ export default {
         if (dept_id === this.$store.state.department.selected_department.id)
           this.$store.commit("SET_SELECTED_DEPARTMENT", '');
         else
-          this.$store.commit("SET_SELECTED_DEPARTMENT", dept_id);
+          this.$store.commit("SET_SELECTED_DEPARTMENT", { id: dept_id, name: dept_name });
       }
     }
   }


### PR DESCRIPTION
# Description
The Department Filter was fixed for the Directory but had unexpected behavior for Courses. This fixes the filtering of Courses based on selection of the department in the Department filter.

# Test Instructions
1. Go to `/courses/S18`
2. Change the value in the select dropdown for Departments
3. Make sure the desired results for Courses is achieved