### PR TITLE
WEB2020-108 Added format filter for course numbers

### DIFF
--- a/src/components/Courses.vue
+++ b/src/components/Courses.vue
@@ -7,7 +7,7 @@
           <section class="container">
             <div class="item" v-for="(course, course_number) in department" :key="course_number">
               <router-link class="course-link" v-for="item in course.courseCodes" :key="item.code" :to="'/courses/course/' + item.code">
-              <h4><em>{{course_number}}</em> | {{course.graduate_level}} | {{course.long_title}}</h4>
+              <h4><em>{{course_number | formatCourseNumber}}</em> | {{course.graduate_level}} | {{course.long_title}}</h4>
               </router-link>
             </div>
           </section>

--- a/src/filter/index.js
+++ b/src/filter/index.js
@@ -158,6 +158,16 @@ export function sortDataByDate (data, dateField, ascendingOrder=true){
   return results;
 }
 
+/**
+ * Custom filter for course numbers. Formats courses with a dash '-'.
+ * @param course
+ * @returns {string}
+ */
+export function formatCourseNumber(course){
+  const separator = '-';
+  return course.substring(0,2) + separator + course.substring(2);
+}
+
 export const SCS_EVENT_COLORS = new Map([
   [ 'special events', '#C60' ],
   [ 'seminars', '#603' ],

--- a/src/views/CourseView.vue
+++ b/src/views/CourseView.vue
@@ -14,7 +14,7 @@
         </p>
       </div>
 
-      <h2>{{course.course_number}} {{course.long_title}}</h2>
+      <h2>{{course.course_number | formatCourseNumber}} {{course.long_title}}</h2>
 
       <p class="body">{{course.description}}</p>
 

--- a/src/views/MemberView.vue
+++ b/src/views/MemberView.vue
@@ -55,7 +55,7 @@
           <section v-if="member.courses.length > 0" class="courses">
             <p class="title">{{semesterCode | seasonTranslate}} Courses</p>
             <p v-for="course in member.courses">
-              <router-link :to="'/courses/course/' + course.course_id"> <span>{{course.course_number}} | {{course.long_title}}</span></router-link>
+              <router-link :to="'/courses/course/' + course.course_id"> <span>{{course.course_number | formatCourseNumber}} | {{course.long_title}}</span></router-link>
             </p>
           </section>
 

--- a/src/views/ResearchAreasView.vue
+++ b/src/views/ResearchAreasView.vue
@@ -16,7 +16,7 @@
     <section v-if="courses" class="area-section">
       <h2 class="title">{{semesterCode | seasonTranslate}} Courses</h2>
       <p v-for="course in courses">
-        <router-link :to="'/courses/course/' + course.course_id"> <span>{{course.course_number}} | {{course.title}}</span></router-link>
+        <router-link :to="'/courses/course/' + course.course_id"> <span>{{course.course_number | formatCourseNumber}} | {{course.title}}</span></router-link>
       </p>
     </section>
     <section v-if="has_news" class="research-news area-section">


### PR DESCRIPTION
### Jira Ticket: WEB2020-108
### Description:
Added a format filter for course numbers so that it places a dash '-' within the course number.
### Test Instructions: 
Verify that the course numbers are formatted correctly on pages:

- Courses List View
- Course Detail view
- Member View
- Research Areas View